### PR TITLE
[FIX] Add missing attribute

### DIFF
--- a/auth_totp/wizards/res_users_authenticator_create.xml
+++ b/auth_totp/wizards/res_users_authenticator_create.xml
@@ -20,7 +20,7 @@
                     <group name="data">
                         <field name="name"/>
                         <field name="user_id"/>
-                        <field name="secret_key" readonly="1"/>
+                        <field name="secret_key" readonly="1" force_save="1"/>
                         <field name="qr_code_tag"/>
                         <field name="confirmation_code"/>
                     </group>


### PR DESCRIPTION
First secret_key value shown to the user on the form as QR Code needs to be saved.
Without force_save attribute it is recalculated and therefore validation is failing.